### PR TITLE
Adding new logic to generate PK

### DIFF
--- a/dwgenerator/sql/standard/create_table.sql
+++ b/dwgenerator/sql/standard/create_table.sql
@@ -3,7 +3,14 @@
 DROP TABLE IF EXISTS {{ target_table.full_name }};
 
 CREATE TABLE {{ target_table.full_name }} (
+  {% if target_table.pk %}
+  {% for column in target_table.columns %}
+  {{ "%-20s" | format(column.name) }} {{ column.type }}{{","}}
+  {% endfor %}
+  CONSTRAINT pk_{{ target_table.name }} PRIMARY KEY ({% for pk in target_table.pk %}{{ pk.name }}{{", " if not loop.last }}{% endfor %})
+  {% else %}
   {% for column in target_table.columns %}
   {{ "%-20s" | format(column.name) }} {{ column.type }}{{"," if not loop.last }}
   {% endfor %}
+  {% endif %}
 );

--- a/dwgenerator/sql/standard/create_table.sql
+++ b/dwgenerator/sql/standard/create_table.sql
@@ -3,14 +3,10 @@
 DROP TABLE IF EXISTS {{ target_table.full_name }};
 
 CREATE TABLE {{ target_table.full_name }} (
+  {% for column in target_table.columns %}
+  {{ "%-20s" | format(column.name) }} {{ column.type }}{{"," if not loop.last or target_table.pk }}
+  {% endfor %}
   {% if target_table.pk %}
-  {% for column in target_table.columns %}
-  {{ "%-20s" | format(column.name) }} {{ column.type }}{{","}}
-  {% endfor %}
   CONSTRAINT pk_{{ target_table.name }} PRIMARY KEY ({% for pk in target_table.pk %}{{ pk.name }}{{", " if not loop.last }}{% endfor %})
-  {% else %}
-  {% for column in target_table.columns %}
-  {{ "%-20s" | format(column.name) }} {{ column.type }}{{"," if not loop.last }}
-  {% endfor %}
   {% endif %}
 );

--- a/tests/test_standard_templates.py
+++ b/tests/test_standard_templates.py
@@ -209,7 +209,7 @@ class TestStandardTemplates(unittest.TestCase):
     self.cur.executescript(ddl)
     result = list(self.cur.execute("PRAGMA db.table_info('customer_h')"))
     expected = [
-      (0, 'customer_key', 'text', 0, None, 0),
+      (0, 'customer_key', 'text', 0, None, 1),
       (1, 'ssn', 'text', 0, None, 0),
       (2, 'load_dts', 'numeric', 0, None, 0),
       (3, 'rec_src', 'text', 0, None, 0)
@@ -247,7 +247,7 @@ class TestStandardTemplates(unittest.TestCase):
     self.cur.executescript(ddl)
     result = list(self.cur.execute("PRAGMA db.table_info('sales_line_customer_l')"))
     expected = [
-      (0, 'sales_line_customer_l_key', 'text', 0, None, 0),
+      (0, 'sales_line_customer_l_key', 'text', 0, None, 1),
       (1, 'sales_line_key', 'text', 0, None, 0),
       (2, 'customer_key', 'text', 0, None, 0),
       (3, 'load_dts', 'numeric', 0, None, 0),
@@ -285,8 +285,8 @@ class TestStandardTemplates(unittest.TestCase):
     self.cur.executescript(ddl)
     result = list(self.cur.execute("PRAGMA db.table_info('customer_s')"))
     expected = [
-      (0, 'customer_key', 'text', 0, None, 0),
-      (1, 'load_dts', 'numeric', 0, None, 0),
+      (0, 'customer_key', 'text', 0, None, 1),
+      (1, 'load_dts', 'numeric', 0, None, 2),
       (2, 'ssn', 'text', 0, None, 0),
       (3, 'name', 'text', 0, None, 0),
       (4, 'rec_src', 'text', 0, None, 0)


### PR DESCRIPTION
Adding new logic to generate PK on create_table.sql template. To be able to validate the template according to new primary key logic test_standard_teamplates.py file got alter to meet the new requirement.